### PR TITLE
Support expected schema for RLHF dataset

### DIFF
--- a/docs/preparation/prepare_data.rst
+++ b/docs/preparation/prepare_data.rst
@@ -81,8 +81,10 @@ In the ``make_map_fn``, each data field should consist of the following
    ``extract_solution`` function. **NOTED** that the implementation of
    the corresponding reward function should align with this extracted
    ``ground_truth``.
-5. ``extra_info``: Record some information of the current prompt. Not
-   use for now.
+5. ``extra_info``: Record auxiliary information of the current prompt. It can
+   include fields such as ``index`` or ``expected_structure`` which will be
+   exposed in the ``non_tensor_batch`` of the resulting ``DataProto`` as
+   ``expected_schema``.
 
 .. code:: python
 

--- a/verl/utils/dataset/rl_dataset.py
+++ b/verl/utils/dataset/rl_dataset.py
@@ -283,6 +283,9 @@ class RLHFDataset(Dataset):
             logger.warning("tools_kwargs is empty for index {}, data source: {}", index, row_dict["data_source"])
         row_dict["index"] = index
         row_dict["tools_kwargs"] = tools_kwargs
+        expected_structure = row_dict.get("extra_info", {}).get("expected_structure")
+        if expected_structure is not None:
+            row_dict["expected_schema"] = expected_structure
         return row_dict
 
     def __getstate__(self):


### PR DESCRIPTION
## Summary
- expose `expected_structure` from RLHF parquet via `expected_schema`
- document expected_schema usage in data preparation guide

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_684b3c5fdcb483238d99e412f65942b2